### PR TITLE
Move bluebird to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
   "bugs": {
     "url": "https://github.com/overlookmotel/bluebird-extra/issues"
   },
-  "dependencies": {
-    "bluebird": "^2.10.1"
-  },
   "devDependencies": {
     "mocha": "^2.3.3",
     "chai": "^3.3.0",
@@ -23,6 +20,9 @@
     "jshint": "^2.8.0",
     "istanbul": "^0.3.21",
     "coveralls": "^2.11.4"
+  },
+  "peerDependencies": {
+    "bluebird": ">=2.10.1"
   },
   "keywords": [
   ],


### PR DESCRIPTION
This moves bluebird to devDependencies and relaxes the constraint on bluebird. This makes it easier to control the exact version, and allows using bluebird@3.
